### PR TITLE
Add support for 'callCustomMethod'

### DIFF
--- a/Wordpress.php
+++ b/Wordpress.php
@@ -165,6 +165,7 @@ class Wordpress extends Component
         'getUsers' => [],
         'getProfile' => [],
         'editProfile' => false,
+        'callCustomMethod' => false,
     ];
 
     /**


### PR DESCRIPTION
Noticed the lack of support for 'callCustomMethod' in the API, complicates extending Wordpress beyond it's base capabilities. 
